### PR TITLE
Add format util function for arxiv edgelist

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,11 @@
 '''
-Reference implementation of node2vec. 
+Reference implementation of node2vec.
 
 Author: Aditya Grover
 
 For more details, refer to the paper:
 node2vec: Scalable Feature Learning for Networks
-Aditya Grover and Jure Leskovec 
+Aditya Grover and Jure Leskovec
 Knowledge Discovery and Data Mining (KDD), 2016
 '''
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,3 +15,32 @@ def convert_embed_to_np(emb_file, np_file):
         mat[r-1] = li
     np.save(np_file, mat)
 
+def format_edgelist(edg_file):
+    '''
+    Converts an edgelist with arbitrarily labelled vertices
+    to edgelist with vertices labeled 1...<num_vertices>
+    '''
+    with open(edg_file) as f:
+        lines = f.readlines()
+
+    # grab all vertices and sort them
+    temp = []
+    for line in lines:
+        str_v = line.split()
+        temp.append(int(str_v[0]))
+        temp.append(int(str_v[1]))
+    vertices = np.unique(temp)
+
+    # create mapping of original vertex
+    # labels to 1...<num_vertices>
+    mapping = {}
+    for x in range(len(vertices)):
+        mapping[vertices[x]] = x+1
+
+    # convert edgelist with new labels
+    outfile = '%s_cleaned.edgelist' % edg_file.split('.')[0]
+    with open(outfile, 'w') as f:
+        for line in lines:
+           str_v = line.split()
+           output = '%d\t%d\n' % (mapping[int(str_v[0])], mapping[int(str_v[1])])
+           f.write(output)


### PR DESCRIPTION
Adds file arxiv.edgelist and utility function to transform it to a file where the nodes are labelled from 1...<num_nodes> -- this resolves issue with running arxiv data through convert_embed_to_np function called from learn_embeddings.