### PR TITLE
Hide portion of edgelist to test link prediction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ build
 .project
 .settings
 .idea
-.npy
-.emb
+*.npy
+*.emb
 .emd
-emb/karate.emb
+*.edgelist
+*.pkl

--- a/src/main.py
+++ b/src/main.py
@@ -33,16 +33,16 @@ def parse_args():
     parser.add_argument('--input_type', nargs='?', default='txt',
                         help='Input graph path. edgelist or graph or npy or txt.')
 
-    parser.add_argument('--dimensions', type=int, default=200,
-                        help='Number of dimensions. Default is 128.')
+    parser.add_argument('--dimensions', type=int, default=100,
+                        help='Number of dimensions. Default is 100.')
 
-    parser.add_argument('--walk-length', type=int, default=80,
-                        help='Length of walk per source. Default is 80.')
+    parser.add_argument('--walk-length', type=int, default=40,
+                        help='Length of walk per source. Default is 40.')
 
-    parser.add_argument('--num-walks', type=int, default=10,
-                        help='Number of walks per source. Default is 10.')
+    parser.add_argument('--num-walks', type=int, default=40,
+                        help='Number of walks per source. Default is 40.')
 
-    parser.add_argument('--window-size', type=int, default=1,
+    parser.add_argument('--window-size', type=int, default=10,
                         help='Context size for optimization. Default is 10.')
 
     parser.add_argument('--iter', default=1, type=int,

--- a/src/trial.py
+++ b/src/trial.py
@@ -1,0 +1,99 @@
+from utils import convert_embed_to_np
+from main import parse_args
+import argparse
+from math import ceil
+import networkx as nx
+import numpy as np
+import node2vec
+import os
+from random import shuffle
+from gensim.models import Word2Vec
+
+c = os.path.dirname(os.path.realpath(__file__))
+
+def graph_with_edges_hidden(percent_hidden):
+    '''
+    Reads input and hides percent_hidden edges from each node.
+    Builds Graph from remaining edges in edgelist.
+    '''
+    filename = '%s/../graph/%s.%s' % (c, args.input_name, args.input_type)
+
+    if args.input_type == "edgelist":
+        if not args.weighted:
+            G = nx.read_edgelist(filename, nodetype=int, create_using=nx.DiGraph())
+            print '@@@', G
+            for edge in G.edges():
+                G[edge[0]][edge[1]]['weight'] = 1
+
+    if not args.directed:
+        G = G.to_undirected()
+
+    n_edges = len(G.edges())
+    edges_to_hide = int(ceil(n_edges * percent_hidden))
+    hidden_edges = []
+
+    nodes = list(nx.nodes(G))
+    shuffle(nodes)
+
+    for u in nodes:
+        neighbors = list(nx.all_neighbors(G, u))
+        n_neighbors = len(neighbors)
+        if n_neighbors > 1:
+            shuffle(neighbors)
+            for v in neighbors:
+                if len(list(nx.all_neighbors(G,v))) > 1:
+                    if edges_to_hide > 0:
+                        G.remove_edge(u, v)
+                        hidden_edges.append([u,v])
+                        edges_to_hide -= 1
+
+    print '%d edges hidden out of %d edges -- %f' % (len(hidden_edges), n_edges, len(hidden_edges)/float(n_edges))
+
+    adj_mat = nx.to_numpy_matrix(G)
+    outfile = '%s/../graph/%s_hidden.npy' % (c, args.input_name)
+    np.save(outfile, adj_mat)
+
+    hidden = np.array(hidden_edges)
+    testfile = '%s/../graph/%s_testlinks.npy' % (c, args.input_name)
+    np.save(testfile, hidden)
+
+    return G, hidden_edges
+
+
+def learn_embeddings(walks):
+    '''
+    Learn embeddings by optimizing the Skipgram objective using SGD.
+    '''
+    walks = [map(str, walk) for walk in walks]
+    print 'Number of walks', len(walks)
+    print 'An example walk', walks[7]
+    model = Word2Vec(walks, size=args.dimensions, window=args.window_size,
+                     min_count=0, sg=1, workers=args.workers, iter=args.iter)
+    emb_file = '%s/../emb/%s.emb' % (c, args.input_name)
+    model.wv.save_word2vec_format(emb_file)
+    print 'args.window_size', args.window_size
+    convert_embed_to_np(emb_file, '%s/../emb/%s_emb_iter_%s_p_%s_q_%s_walk_%s_win_%s.npy' % \
+        (c, args.input_name, args.iter, args.p, args.q, args.num_walks, args.window_size))
+
+    return
+
+
+def main(args):
+    '''
+    Pipeline for representational learning for all nodes in a graph.
+    '''
+    print 'Reading graph'
+    nx_G, hidden_edges = graph_with_edges_hidden(0.15)
+    print 'Creating node2vec graph'
+    G = node2vec.Graph(nx_G, args.directed, args.p, args.q)
+    print 'Preprocessing'
+    G.preprocess_transition_probs()
+    print 'Generating walks'
+    walks = G.simulate_walks(args.num_walks, args.walk_length)
+    print 'Learning embeddings'
+    learn_embeddings(walks)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 def convert_embed_to_np(emb_file, np_file):
     print 'Convert %s to %s' % (emb_file, np_file)
@@ -14,6 +15,7 @@ def convert_embed_to_np(emb_file, np_file):
         li = [ float(x) for x in t[1:] ]
         mat[r-1] = li
     np.save(np_file, mat)
+
 
 def format_edgelist(edg_file):
     '''
@@ -44,3 +46,14 @@ def format_edgelist(edg_file):
            str_v = line.split()
            output = '%d\t%d\n' % (mapping[int(str_v[0])], mapping[int(str_v[1])])
            f.write(output)
+
+
+def convert_emb_to_pd(emb_file, pd_file):
+    print 'Convert %s to %s' % (emb_file, pd_file)
+    df = pd.read_table(emb_file, \
+        delim_whitespace=True, \
+        header=None, \
+        dtype=np.float64, \
+        index_col=0, \
+        skiprows=1)
+    df.to_pickle(pd_file)


### PR DESCRIPTION
This pull request does the following:

- Updates parameters for node2vec (`main.py`) to agree with SDNE paper

- Creates function to hide portion of edgelist and create Graph (and network embedding) from it (`trial.py`)

- Add util function to save network embedding as pandas dataframe

Usage for `trial.py`: 
```
> python src/trial.py --input_name <arxiv-dataset> --input_type edgelist
```